### PR TITLE
Use port 443 for TLS

### DIFF
--- a/charts/av-scan-service/templates/deployment.yaml
+++ b/charts/av-scan-service/templates/deployment.yaml
@@ -54,7 +54,11 @@ spec:
             {{- toYaml .Values.avScanService.resources | nindent 12 }}
           ports:
             - name: http
+              {{- if .Values.tls.enabled }}
+              containerPort: 8443
+              {{- else }}
               containerPort: 8080
+              {{- end }}
               protocol: TCP
           {{- if .Values.avScanService.livenessProbe }}
           livenessProbe: {{ include "av-scan-service.livenessProbe" . | nindent 12 }}

--- a/charts/av-scan-service/templates/service.yaml
+++ b/charts/av-scan-service/templates/service.yaml
@@ -13,9 +13,13 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: 80
-      targetPort: http
+    - targetPort: http
       protocol: TCP
       name: http
+      {{- if .Values.tls.enabled }}
+      containerPort: 443
+      {{- else }}
+      containerPort: 80
+      {{- end }}
   selector:
     {{- include "av-scan-service.selectorLabels" . | nindent 4 }}

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -33,6 +33,8 @@ For the full list of supported options and their defaults, see [values.yaml](/ch
 
 AV API can be configured with tls. It can be done manually or using cert-manager/openshift integration. The steps for every possible approach are provided below.
 
+**Note:** if TLS is enabled, av-scan-service Service accepts HTTPS traffic on port 443, instead of port 80.
+
 #### Manually Created tls Certificates
 
 1. Create configuration file for SSL certificate:  


### PR DESCRIPTION
### Problem
Currently, if TLS is enabled in av-scan-service, it still listens on port 80, which is misleading. Usually port 80 serves HTTP, and port 443 serves HTTPS

### Solution
* Move container to different ports depending on HTTP (8080) or HTTPS (8443)
* Move service to different ports depending on HTTP (80) or HTTPS (443)